### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "yiisoft/yii2-swiftmailer": "*",
     "omnilight/yii2-shopping-cart": "*",
     "kartik-v/yii2-widgets": "*",
-    "zelenin/yii2-slug-behavior": "~0.2@stable",
+    "zelenin/yii2-slug-behavior": "~1.5.1",
     "vova07/yii2-imperavi-widget": "*",
     "2amigos/yii2-gallery-widget": "*",
     "himiklab/yii2-sortable-grid-view-widget": "*",


### PR DESCRIPTION
Behavior doesn't work after upgrading yii2 to 2.0.6
-> Access level to Zelenin\yii\behaviors\Slug::validateSlug() must be protected (as in class yii\behaviors\SluggableBehavior) or weaker
